### PR TITLE
Change package's name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Feedback form",
+  "name": "feedback-form",
   "version": "0.1.0",
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
Invalid package's name contain **illegal** characters causing installation of dependencies to fail.

`npm install` and `yarn install` failing:
<img width="711" alt="captura de pantalla 2018-02-19 a la s 11 07 33" src="https://user-images.githubusercontent.com/20796057/36382002-41eb5dec-1566-11e8-9128-24e8bc0b0046.png">
